### PR TITLE
Add TypeScript Page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -9,6 +9,7 @@
   - [Hello, World](getting_started/hello_world.md)
     - [Breakdown](getting_started/breakdown.md)
   - [TornadoCash](getting_started/tornado_cash.md)
+  - [TypeScript](getting_started/typescript.md)
 - [Language Concepts](language_concepts.md)
   - [Mutability](language_concepts/mutability.md)
   - [Data types](language_concepts/data_types.md)

--- a/src/getting_started/nargo.md
+++ b/src/getting_started/nargo.md
@@ -2,4 +2,4 @@
 
 `nargo` is a command line tool for interacting with Noir programs (e.g. compiling, proving, verifying and more).
 
-Alternatively, the interactions can also be performed in TypeScript.
+Alternatively, the interactions can also be performed in [TypeScript](typescript.md).

--- a/src/getting_started/nargo/commands.md
+++ b/src/getting_started/nargo/commands.md
@@ -15,7 +15,7 @@ Creates a new Noir project.
 _Arguments_
 
 - `<package_name>` - Name of the package
-- `<path>` - The path to save the new project
+- `[path]` - The path to save the new project
 
 ## `nargo build`
 
@@ -41,16 +41,21 @@ _Arguments_
 
 Generate a Solidity smart contract verifier for the program.
 
-## `nargo compile <circuit_name>`
+## `nargo compile [FLAGS] <circuit_name>`
 
 Compile the program and its secret execution trace into [ACIR](../../acir.md) format.
 
 _Arguments_
 
 - `<circuit_name>` - The name of the ACIR file
+- `[FLAGS]` - Add `--witness` to compile the witness file as well
 
 _Usage_
 
-Fill in the values in `Prover.toml` generated from `nargo build`, then run the command. A new folder `build` should then be generated in your project directory, containing `<circuit_name>.acir` and `<circuit_name>.tr`.
+Running the command would create a new folder `build` with the compiled `<circuit_name>.acir` file in your project directory.
 
-The `.acir` file is the ACIR of your Noir program, and the `.tr` file is the witness file. The witness file can be considered as program inputs parsed for your program's ACIR. The files compiled can be passed into a TypeScript project for proving and verification. See the [TypeScript](../typescript.md#proving-and-verifying-externally-compiled-files) section to learn more.
+To also compile a witness file, fill in the values in `Prover.toml` generated from `nargo build` and run the command with the `--witness` flag. A `<circuit_name>.tr` file would be compiled in the `build` folder.
+
+> **Info:** The `.acir` file is the ACIR of your Noir program, and the `.tr` file is the witness file. The witness file can be considered as program inputs parsed for your program's ACIR.
+>
+> The files compiled can be passed into a TypeScript project for proving and verification. See the [TypeScript](../typescript.md#proving-and-verifying-externally-compiled-files) section to learn more.

--- a/src/getting_started/nargo/commands.md
+++ b/src/getting_started/nargo/commands.md
@@ -19,7 +19,7 @@ _Arguments_
 
 ## `nargo build`
 
-Generate the `toml` files for specifying in/output values of the Noir program.
+Generate the `Prover.toml` and `Verifier.toml` files for specifying prover and verifier in/output values of the Noir program respectively.
 
 ## `nargo prove <proof_name>`
 
@@ -39,12 +39,18 @@ _Arguments_
 
 ## `nargo contract`
 
-Generate a smart contract verifier for the program.
+Generate a Solidity smart contract verifier for the program.
 
 ## `nargo compile <circuit_name>`
 
-Compile the program and its secret execution trace into Abstract Circuit Intermediate Representation (ACIR) format.
+Compile the program and its secret execution trace into [ACIR](../../acir.md) format.
 
 _Arguments_
 
 - `<circuit_name>` - The name of the ACIR file
+
+_Usage_
+
+Fill in the values in `Prover.toml` generated from `nargo build`, then run the command. A new folder `build` should then be generated in your project directory, containing `<circuit_name>.acir` and `<circuit_name>.tr`.
+
+The `.acir` file is the ACIR of your Noir program, and the `.tr` file is the witness file. The witness file can be considered as program inputs parsed for your program's ACIR. The files compiled can be passed into a TypeScript project for proving and verification. See the [TypeScript](../typescript.md#proving-and-verifying-externally-compiled-files) section to learn more.

--- a/src/getting_started/typescript.md
+++ b/src/getting_started/typescript.md
@@ -1,0 +1,159 @@
+# TypeScript
+
+Interactions with Noir programs can also be performed in TypeScript, which can come in handy when writing tests or when working in TypeScript-based projects like [Hardhat].
+
+The following sections use the [_Standard Noir Example_] as an example to dissect a typical Noir workflow in TypeScript, with specific focus on its:
+
+- Test script [`1_mul.ts`]
+- Noir program [main.nr]
+- Verifier contract generator script [generate_sol_verifier.ts]
+
+[Hardhat]: https://hardhat.org/
+[_Standard Noir Example_]: https://github.com/vezenovm/basic_mul_noir_example
+[`1_mul.ts`]: https://github.com/vezenovm/basic_mul_noir_example/blob/master/test/1_mul.ts
+[main.nr]: https://github.com/vezenovm/basic_mul_noir_example/blob/master/circuits/src/main.nr
+[generate_sol_verifier.ts]: https://github.com/vezenovm/basic_mul_noir_example/blob/master/scripts/generate_sol_verifier.ts
+
+## Setup
+
+Install Noir dependencies in your project by running:
+
+```bash
+$ yarn add @noir-lang/noir_wasm @noir-lang/barretenberg @noir-lang/aztec_backend
+```
+
+And import the applicable functions into your TypeScript file by adding:
+
+```ts
+// 1_mul.ts
+import { compile, acir_from_bytes } from '@noir-lang/noir_wasm';
+import { setup_generic_prover_and_verifier, create_proof, verify_proof, create_proof_with_witness } from '@noir-lang/barretenberg/dest/client_proofs';
+import { packed_witness_to_witness, serialise_public_inputs, compute_witnesses } from '@noir-lang/aztec_backend';
+```
+
+## Compiling
+
+To begin proving and verifying a Noir program, it first needs to be compiled by calling `noir_wasm`'s `compile` function:
+
+```ts
+// 1_mul.ts
+const compiled_program = compile(path.resolve(__dirname, "../circuits/src/main.nr"));
+```
+
+The `compiled_program` returned by the function contains the Abstract Circuit Intermediate Representation (ACIR) and the Application Binary Interface (ABI) of your Noir program. They shall be stored for proving your program later:
+
+```ts
+// 1_mul.ts
+let acir = compiled_program.circuit;
+const abi = compiled_program.abi;
+```
+
+## Specifying Inputs
+
+Having obtained the compiled program, the program inputs shall then be specified in its ABI.
+
+_Standard Noir Example_ is a program that multiplies input `x` with input `y` and returns the result:
+
+```noir
+# main.nr
+fn main(x: u32, y: pub u32) -> pub u32 {
+    let z = x * y;
+    z
+}
+```
+
+Hence, one valid scenario for proving could be `x = 3`, `y = 4` and `return = 12`:
+
+```ts
+// 1_mul.ts
+abi.x = 3;
+abi.y = 4;
+abi.return = 12;
+```
+
+> **Note:** Return values are also required to be specified, as they are merely syntax sugar of inputs with equality constraints.
+
+## Initializing Prover & Verifier
+
+Prior to proving and verifying, the prover and verifier have to first be initialized by calling `barretenberg`'s `setup_generic_prover_and_verifier` with your Noir program's ACIR:
+
+```ts
+// 1_mul.ts
+let [prover, verifier] = await setup_generic_prover_and_verifier(acir);
+```
+
+## Proving
+
+The Noir program can then be executed and proved by calling `barretenberg`'s `create_proof` function:
+
+```ts
+// 1_mul.ts
+const proof = await create_proof(prover, acir, abi);
+```
+
+## Verifying
+
+The `proof` obtained can be verified by calling `barretenberg`'s `verify_proof` function:
+
+```ts
+// 1_mul.ts
+const verified = await verify_proof(verifier, proof);
+```
+
+The function should return `true` if the entire process is working as intended, which can be asserted if you are writing a test script:
+
+```ts
+// 1_mul.ts
+expect(verified).eq(true);
+```
+
+## Verifying with Smart Contract
+
+Alternatively, a verifier smart contract can be generated in TypeScript as well:
+
+```ts
+// generate_sol_verifier.ts
+import { writeFileSync } from 'fs';
+
+...
+
+const sc = verifier.SmartContract();
+syncWriteFile("../contracts/plonk_vk.sol", sc);
+
+...
+
+function syncWriteFile(filename: string, data: any) {
+    writeFileSync(join(__dirname, filename), data, {
+      flag: 'w',
+    });
+}
+```
+
+Which can then be used to verify Noir proofs: 
+
+```ts
+// 1_mul.ts
+import { ethers } from "hardhat";
+import { Contract, ContractFactory, utils } from 'ethers';
+
+...
+
+// Deploy verifier contract
+let Verifier: ContractFactory;
+let verifierContract: Contract;
+
+before(async () => {
+    Verifier = await ethers.getContractFactory("TurboVerifier");
+    verifierContract = await Verifier.deploy();
+});
+
+...
+
+const sc_verified = await verifierContract.verify(proof);
+expect(sc_verified).eq(true)
+```
+
+For more inspiration on ways to interact with Noir programs in TypeScript, see the full scripts [`1_mul.ts` of _Standard Noir Example_] and [`mm.ts` of _Mastermind in Noir_].
+
+[`1_mul.ts` of _Standard Noir Example_]: https://github.com/vezenovm/basic_mul_noir_example/blob/master/test/1_mul.ts
+[`mm.ts` of _Mastermind in Noir_]: https://github.com/vezenovm/mastermind-noir/blob/master/test/mm.ts

--- a/src/getting_started/typescript.md
+++ b/src/getting_started/typescript.md
@@ -43,7 +43,7 @@ To begin proving and verifying a Noir program, it first needs to be compiled by 
 const compiled_program = compile(path.resolve(__dirname, "../circuits/src/main.nr"));
 ```
 
-The `compiled_program` returned by the function contains the Abstract Circuit Intermediate Representation (ACIR) and the Application Binary Interface (ABI) of your Noir program. They shall be stored for proving your program later:
+The `compiled_program` returned by the function contains the [ACIR](../acir.md) and the Application Binary Interface (ABI) of your Noir program. They shall be stored for proving your program later:
 
 ```ts
 // 1_mul.ts

--- a/src/getting_started/typescript.md
+++ b/src/getting_started/typescript.md
@@ -19,6 +19,8 @@ You are also welcome to revisit the full scripts [`1_mul.ts`] of _Standard Noir 
 
 ## Setup
 
+Install [Yarn] and [Node.js].
+
 Install Noir dependencies in your project by running:
 
 ```bash
@@ -33,6 +35,9 @@ import { compile, acir_from_bytes } from '@noir-lang/noir_wasm';
 import { setup_generic_prover_and_verifier, create_proof, verify_proof, create_proof_with_witness } from '@noir-lang/barretenberg/dest/client_proofs';
 import { packed_witness_to_witness, serialise_public_inputs, compute_witnesses } from '@noir-lang/aztec_backend';
 ```
+
+[Yarn]: https://classic.yarnpkg.com/lang/en/docs/install/
+[Node.js]: https://nodejs.org/en/download/
 
 ## Compiling
 

--- a/src/getting_started/typescript.md
+++ b/src/getting_started/typescript.md
@@ -5,8 +5,8 @@ Interactions with Noir programs can also be performed in TypeScript, which can c
 The following sections use the [_Standard Noir Example_] as an example to dissect a typical Noir workflow in TypeScript, with specific focus on its:
 
 - Test script [`1_mul.ts`]
-- Noir program [main.nr]
-- Verifier contract generator script [generate_sol_verifier.ts]
+- Noir program [`main.nr`]
+- Verifier contract generator script [`generate_sol_verifier.ts`]
 
 [Hardhat]: https://hardhat.org/
 [_Standard Noir Example_]: https://github.com/vezenovm/basic_mul_noir_example
@@ -109,7 +109,11 @@ expect(verified).eq(true);
 
 ## Verifying with Smart Contract
 
-Alternatively, a verifier smart contract can be generated in TypeScript as well:
+Alternatively, a verifier smart contract can be generated and used for verifying Noir proofs in TypeScript as well.
+
+This could be useful if the Noir program is designed to be decentrally verified and/or make use of decentralized states and logics that is handled at the smart contract level.
+
+To generate the verifier smart contract:
 
 ```ts
 // generate_sol_verifier.ts
@@ -117,6 +121,7 @@ import { writeFileSync } from 'fs';
 
 ...
 
+// Generate verifier contract
 const sc = verifier.SmartContract();
 syncWriteFile("../contracts/plonk_vk.sol", sc);
 
@@ -129,7 +134,7 @@ function syncWriteFile(filename: string, data: any) {
 }
 ```
 
-Which can then be used to verify Noir proofs: 
+To verify a Noir proof using the verifier contract:
 
 ```ts
 // 1_mul.ts
@@ -149,6 +154,7 @@ before(async () => {
 
 ...
 
+// Verify proof
 const sc_verified = await verifierContract.verify(proof);
 expect(sc_verified).eq(true)
 ```


### PR DESCRIPTION
Preview: https://globallager.github.io/book/

Mostly adapted from the [Noir guide](https://docs.aztec.network/developers/noir#working-with-noir-programs-in-typescript) in Aztec Docs.

Supplemented the Commands page with relevant info as well.