### PR TITLE
Changes for `const` to `comptime` 

### DIFF
--- a/src/language_concepts/control_flow.md
+++ b/src/language_concepts/control_flow.md
@@ -9,7 +9,7 @@ The following block of code between the braces is run 10 times.
 ```rust,noplaypen
 for i in 0..10 {
     // do something
-}
+};
 ```
 
 ## If Expressions

--- a/src/language_concepts/data_types.md
+++ b/src/language_concepts/data_types.md
@@ -62,9 +62,9 @@ Below we show how to declare a constant value:
 
 ```rust,noplaypen
 fn main() {
-    let a: const Field = 5;
+    let a: comptime Field = 5;
 
-    // `const Field` can also be inferred:
+    // `comptime Field` can also be inferred:
     let a = 5;
 }
 ```
@@ -73,20 +73,22 @@ Note that variables declared as mutable may not be constants:
 
 ```rust,noplaypen
 fn main() {
-    // error: Cannot mark a const type as mutable - any mutation would remove its const-ness
-    let mut a: const Field = 5;
+    // error: Cannot mark a comptime type as mutable - any mutation would remove its const-ness
+    let mut a: comptime Field = 5;
 
     // a inferred as a private Field here
     let mut a = 5;
 }
 ```
 
-#### Global Constants
+#### Globals
 
-Constants can also be global; however, they must be declared `const` and explicitly type annotated. They can then be used like any other constant inside functions. Global consts can also be used to specify array annotations for function parameters and can be imported from submodules. 
+Noir also supports global variables. However, they must be compile-time variables. If `comptime` is not explicitly written in the type annotation the compiler will implicitly specify the declaration as compile-time. They can then be used like any other compile-time variable inside functions. The global type can also be inferred by the compiler entirely. Globals can also be used to specify array annotations for function parameters and can be imported from submodules. 
+
+Globals are currently limited to Field, integer, and bool literals.
 
 ```rust,noplaypen
-const N: Field = 5;
+global N: Field = 5; // Same as `global N: comptime Field = 5`
 
 fn main(x : Field, y : [Field; N]) {
     let res = x * N;
@@ -100,9 +102,9 @@ fn main(x : Field, y : [Field; N]) {
 mod mysubmodule {
     use dep::std;
 
-    const N: Field = 10;
+    global N: Field = 10;
 
-    fn my_helper() -> const Field {
+    fn my_helper() -> comptime Field {
         let x = N;
         x
     }
@@ -195,7 +197,7 @@ The first field name of a tuple is `0`, then `1` and so on:
 
 ```
 fn main() {
-    // tuple: (const Field, const Field, const Field, const Field)
+    // tuple: (comptime Field, comptime Field, comptime Field, comptime Field)
     let tuple = (5, 6, 7, 8);
 
     let five = tuple.0;


### PR DESCRIPTION
This PR mainly makes changes to update usage of the `const` to `comptime`. 

It also adds a semicolon to the for expr example we have. We require semicolons to be used with for-loops and not having it is confusing to devs and can lead to pain points when first trying to use the language.