### PR TITLE
Update "Installation" Page

### DIFF
--- a/src/getting_started/nargo.md
+++ b/src/getting_started/nargo.md
@@ -1,5 +1,5 @@
 # Nargo
 
-`nargo` is a command line tool for interacting with Noir programs (e.g. compiling, proving, verifying and more).
+Nargo is a command line tool for interacting with Noir programs (e.g. compiling, proving, verifying and more).
 
 Alternatively, the interactions can also be performed in [TypeScript](typescript.md).

--- a/src/getting_started/nargo/installation.md
+++ b/src/getting_started/nargo/installation.md
@@ -14,13 +14,13 @@ There are two approaches to install Nargo:
    _macOS_
 
    ```bash
-   mkdir ~/nargo
+   mkdir -p ~/.nargo/bin
    ```
 
    _Windows_
 
    ```sh
-   mkdir C:\nargo
+   mkdir C:\.nargo\bin
    ```
 
 2. Download the binary package from [GitHub Releases](https://github.com/noir-lang/noir/releases/tag/nightly) according to your OS, and move it into the directory created in Step 1:
@@ -29,41 +29,43 @@ There are two approaches to install Nargo:
    - macOS (Intel): `nargo-x86_64-apple-darwin.tar.gz`
    - Windows: `nargo-x86_64-pc-windows-msvc.zip`
 
+   > **macOS:** If you cannot find the _.nargo_ directory created, press _Command+Shift+._ in Finder to view hidden files.
+
 3. Paste and run the following in the terminal to extract and install the binary:
 
    _macOS (Apple Silicon)_
 
    ```bash
-   cd ~/nargo && \
+   cd ~/.nargo/bin && \
    gunzip -c nargo-aarch64-apple-darwin.tar.gz | tar xopf - && \
    chmod +x nargo && \
-   echo '\nexport PATH=$PATH:~/nargo' >> ~/.zshrc && \
+   echo '\nexport PATH=$PATH:~/.nargo/bin' >> ~/.zshrc && \
    source ~/.zshrc
    ```
 
    _macOS (Intel)_
 
    ```bash
-   cd ~/nargo && \
+   cd ~/.nargo/bin && \
    gunzip -c nargo-x86_64-apple-darwin.tar.gz | tar xopf - && \
    chmod +x nargo && \
-   echo '\nexport PATH=$PATH:~/nargo' >> ~/.zshrc && \
+   echo '\nexport PATH=$PATH:~/.nargo/bin' >> ~/.zshrc && \
    source ~/.zshrc
    ```
 
    _Windows (PowerShell)_
 
    ```sh
-   cd C:\nargo;`
+   cd C:\.nargo\bin;`
    Expand-Archive nargo-x86_64-pc-windows-msvc.zip; `
-   $Env:PATH += ";C:\nargo\nargo-x86_64-pc-windows-msvc"
+   $Env:PATH += ";C:\.nargo\bin\nargo-x86_64-pc-windows-msvc"
    ```
 
 4. Check if the installation was successful by running `nargo --help`.
 
-   > **Note:** For macOS users, you may be prompted with an OS alert.
+   > **macOS:** If you are prompted with an OS alert, right-click and open the _nargo_ executable from Finder.
    >
-   > In Finder, right-click and open the nargo executable. You can close the new terminal that popped up and `nargo` should now be accessible.
+   > You can close the new terminal that popped up and `nargo` should now be accessible.
 
    For a successful installation, you should see something similar to the following after running the command:
 

--- a/src/getting_started/nargo/installation.md
+++ b/src/getting_started/nargo/installation.md
@@ -1,21 +1,107 @@
 # Installation
 
-## Setup
+Ways to install Nargo are described in ascending order of complexity below.
 
-1. Install [Git] and [Rust].
+## Option 1: Binaries
 
-   Optionally you can install [Noir VS Code extension] for syntax highlighting as well.
+**Platforms Supported:** macOS, Windows
+
+1. Create a directory to host the binary. For example, run:
+
+   ```bash
+   mkdir ~/nargo
+   ```
+
+2. Download the binary package from GitHub into the directory created in Step 1:
+
+   - [macOS (Apple Silicon)](https://github.com/kobyhallx/build-noir/suites/9553357751/artifacts/454490397)
+   - [macOS (Intel)](https://github.com/kobyhallx/build-noir/suites/9553357751/artifacts/454490398)
+   - [Windows](https://github.com/kobyhallx/build-noir/suites/9553445421/artifacts/454485541)
+
+3. Paste and run the following in the terminal to extract and expose the binary:
+
+   _macOS (Apple Silicon)_
+
+   ```bash
+   cd ~/nargo && \
+   unzip nargo-aarch64-apple-darwin.zip && \
+   chmod +x nargo && \
+   echo 'export PATH=$PATH:~/nargo' >> ~/.zshrc && \
+   source ~/.zshrc
+   ```
+
+   To Test: _macOS (Intel)_
+
+   ```bash
+   cd ~/nargo && \
+   unzip nargo-x86_64-apple-darwin.zip && \
+   chmod +x nargo && \
+   echo 'export PATH=$PATH:~/nargo' >> ~/.zshrc && \
+   source ~/.zshrc
+   ```
+
+   To Test: _Windows_
+
+   ```bash
+   cd ~/nargo && \
+   unzip nargo-x86_64-pc-windows-msvc.zip && \
+   setx PATH "~/nargo;%PATH%"
+   ```
+
+4. Check if the installation was successful by running `nargo --help`.
+
+   If you are prompted with an OS alert, follow the instructions to grant the necessary permissions:
+
+   - _macOS_
+
+     Proceed with "Show in Finder", then right-click and open the nargo executable. You can close the new terminal that popped up and `nargo` should now be accessible.
+
+   For a successful installation, you should see something similar to the following after running the command:
+
+   ```
+   $ nargo --help
+   nargo 0.1
+   Kevaundray Wedderburn <kevtheappdev@gmail.com>
+   Noir's package manager
+
+   USAGE:
+      nargo [SUBCOMMAND]
+
+   FLAGS:
+      -h, --help       Prints help information
+      -V, --version    Prints version information
+
+   SUBCOMMANDS:
+      build       Builds the constraint system
+      compile     Compile the program and its secret execution trace into ACIR format
+      contract    Creates the smart contract code for circuit
+      gates       Counts the occurences of different gates in circuit
+      help        Prints this message or the help of the given subcommand(s)
+      new         Create a new binary project
+      prove       Create proof for this program
+      verify      Given a proof and a program, verify whether the proof is valid
+   ```
+
+Optionally you can also install [Noir VS Code extension] for syntax highlighting.
+
+## Option 2: Compile from Source
+
+**Platforms Supported:** Linux, macOS (and Windows with Option 2.1)
+
+### Setup
+
+1. Install [Git] and [Rust]. Optionally you can also install [Noir VS Code extension] for syntax highlighting.
 
 2. Download Noir's source code from Github by running:
 
    ```bash
-   $ git clone git@github.com:noir-lang/noir.git
+   git clone git@github.com:noir-lang/noir.git
    ```
 
 3. Change directory into the Nargo crate by running:
 
    ```bash
-   $ cd noir/crates/nargo
+   cd noir/crates/nargo
    ```
 
 [git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
@@ -24,7 +110,7 @@
 
 There are then two approaches to proceed, differing in how the proving backend is installed:
 
-## Option 1: WASM Executable Backend
+### Option 2.1: WASM Executable Backend
 
 **Platforms Supported:** Linux, macOS, Windows
 
@@ -34,7 +120,7 @@ There are then two approaches to proceed, differing in how the proving backend i
    aztec_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "fb42a54a04f3952f422e8fa4eff4f8eb2ca4e51b" }
    ```
 
-## Option 2: Compile Backend from Source
+### Option 2.2: Compile Backend from Source
 
 **Platforms Supported:** Linux, macOS
 
@@ -47,7 +133,7 @@ For macOS users, installing through [Homebrew] is highly recommended.
    _macOS_
 
    ```bash
-   $ brew install cmake llvm libomp
+   brew install cmake llvm libomp
    ```
 
    _Linux_
@@ -75,15 +161,15 @@ For macOS users, installing through [Homebrew] is highly recommended.
 [llvm]: https://llvm.org/docs/GettingStarted.html
 [openmp]: https://openmp.llvm.org/
 
-## Continue with Installation
+### Continue with Installation
 
 5. Install Nargo by running:
 
    ```bash
-   $ cargo install --locked --path=.
+   cargo install --locked --path=.
    ```
 
-6. Check if the installation was successful by running:
+6. Check if the installation was successful by running `nargo --help`:
 
    ```
    $ nargo --help

--- a/src/getting_started/nargo/installation.md
+++ b/src/getting_started/nargo/installation.md
@@ -26,7 +26,7 @@ Ways to install Nargo are described in ascending order of complexity below.
    cd ~/nargo && \
    unzip nargo-aarch64-apple-darwin.zip && \
    chmod +x nargo && \
-   echo 'export PATH=$PATH:~/nargo' >> ~/.zshrc && \
+   echo '\nexport PATH=$PATH:~/nargo' >> ~/.zshrc && \
    source ~/.zshrc
    ```
 
@@ -36,7 +36,7 @@ Ways to install Nargo are described in ascending order of complexity below.
    cd ~/nargo && \
    unzip nargo-x86_64-apple-darwin.zip && \
    chmod +x nargo && \
-   echo 'export PATH=$PATH:~/nargo' >> ~/.zshrc && \
+   echo '\nexport PATH=$PATH:~/nargo' >> ~/.zshrc && \
    source ~/.zshrc
    ```
 

--- a/src/getting_started/nargo/installation.md
+++ b/src/getting_started/nargo/installation.md
@@ -12,15 +12,15 @@
    $ git clone git@github.com:noir-lang/noir.git
    ```
 
-3. Change directory into the nargo crate by running:
+3. Change directory into the Nargo crate by running:
 
    ```bash
    $ cd noir/crates/nargo
    ```
 
-[Git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
-[Rust]: https://www.rust-lang.org/tools/install
-[Noir VS Code extension]: https://marketplace.visualstudio.com/items?itemName=noir-lang.noir-programming-language-syntax-highlighter
+[git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
+[rust]: https://www.rust-lang.org/tools/install
+[noir vs code extension]: https://marketplace.visualstudio.com/items?itemName=noir-lang.noir-programming-language-syntax-highlighter
 
 There are then two approaches to proceed, differing in how the proving backend is installed:
 
@@ -31,10 +31,8 @@ There are then two approaches to proceed, differing in how the proving backend i
 4. Go into `nargo/Cargo.toml` and replace `aztec_backend = ...` with the following:
 
    ```
-   aztec_backend = { optional = true, git = "https://github.com/noir-lang/aztec_backend", features = ["wasm-base"] , default-features = false }
+   aztec_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "fb42a54a04f3952f422e8fa4eff4f8eb2ca4e51b" }
    ```
-
-> **Note:** `nargo contract` has not been implemented yet for _wasm-base_ `nargo` installations.
 
 ## Option 2: Compile Backend from Source
 
@@ -46,9 +44,19 @@ For macOS users, installing through [Homebrew] is highly recommended.
 
 4. Install [CMake], [LLVM] and [OpenMP] by running:
 
-   <!---
-   TODO: Supplement Linux scripts.
+   _macOS_
 
+   ```bash
+   $ brew install cmake llvm libomp
+   ```
+
+   _Linux_
+
+   ```bash
+   TBC
+   ```
+
+   <!---
    Linux's command for openMP from barretenberg's GitHub README:
 
    ```bash
@@ -61,12 +69,6 @@ For macOS users, installing through [Homebrew] is highly recommended.
    ```
    --->
 
-   _macOS_
-
-   ```bash
-   $ brew install cmake llvm libomp
-   ```
-
 [barretenberg]: https://github.com/AztecProtocol/aztec-connect/tree/master/barretenberg
 [homebrew]: https://brew.sh/
 [cmake]: https://cmake.org/install/
@@ -75,7 +77,7 @@ For macOS users, installing through [Homebrew] is highly recommended.
 
 ## Continue with Installation
 
-5. Install nargo by running:
+5. Install Nargo by running:
 
    ```bash
    $ cargo install --locked --path=.
@@ -84,7 +86,7 @@ For macOS users, installing through [Homebrew] is highly recommended.
 6. Check if the installation was successful by running:
 
    ```
-   $ nargo help
+   $ nargo --help
    nargo 0.1
    Kevaundray Wedderburn <kevtheappdev@gmail.com>
    Noir's package manager
@@ -100,6 +102,7 @@ For macOS users, installing through [Homebrew] is highly recommended.
       build       Builds the constraint system
       compile     Compile the program and its secret execution trace into ACIR format
       contract    Creates the smart contract code for circuit
+      gates       Counts the occurences of different gates in circuit
       help        Prints this message or the help of the given subcommand(s)
       new         Create a new binary project
       prove       Create proof for this program

--- a/src/getting_started/nargo/installation.md
+++ b/src/getting_started/nargo/installation.md
@@ -1,15 +1,26 @@
 # Installation
 
-Ways to install Nargo are described in ascending order of complexity below.
+There are two approaches to install Nargo:
+
+- [Option 1: Binaries](#option-1-binaries)
+- [Option 2: Compile from Source](#option-2-compile-from-source)
 
 ## Option 1: Binaries
 
-**Platforms Supported:** macOS, Windows
+> **Platforms Supported:** macOS, Windows
 
 1. Create a directory to host the binary. For example, run:
 
+   _macOS_
+
    ```bash
    mkdir ~/nargo
+   ```
+
+   _Windows_
+
+   ```sh
+   mkdir C:\nargo
    ```
 
 2. Download the binary package from GitHub into the directory created in Step 1:
@@ -30,7 +41,7 @@ Ways to install Nargo are described in ascending order of complexity below.
    source ~/.zshrc
    ```
 
-   To Test: _macOS (Intel)_
+   _macOS (Intel)_
 
    ```bash
    cd ~/nargo && \
@@ -40,21 +51,19 @@ Ways to install Nargo are described in ascending order of complexity below.
    source ~/.zshrc
    ```
 
-   To Test: _Windows_
+   _Windows (PowerShell)_
 
-   ```bash
-   cd ~/nargo && \
-   unzip nargo-x86_64-pc-windows-msvc.zip && \
-   setx PATH "~/nargo;%PATH%"
+   ```sh
+   cd C:\nargo;`
+   Expand-Archive nargo-x86_64-pc-windows-msvc.zip; `
+   $Env:PATH += ";C:\nargo\nargo-x86_64-pc-windows-msvc"
    ```
 
 4. Check if the installation was successful by running `nargo --help`.
 
-   If you are prompted with an OS alert, follow the instructions to grant the necessary permissions:
-
-   - _macOS_
-
-     Proceed with "Show in Finder", then right-click and open the nargo executable. You can close the new terminal that popped up and `nargo` should now be accessible.
+   > **Note:** For macOS users, you may be prompted with an OS alert.
+   >
+   > In Finder, right-click and open the nargo executable. You can close the new terminal that popped up and `nargo` should now be accessible.
 
    For a successful installation, you should see something similar to the following after running the command:
 
@@ -86,7 +95,7 @@ Optionally you can also install [Noir VS Code extension] for syntax highlighting
 
 ## Option 2: Compile from Source
 
-**Platforms Supported:** Linux, macOS (and Windows with Option 2.1)
+> **Platforms Supported:** Linux, macOS, Windows
 
 ### Setup
 
@@ -112,7 +121,7 @@ There are then two approaches to proceed, differing in how the proving backend i
 
 ### Option 2.1: WASM Executable Backend
 
-**Platforms Supported:** Linux, macOS, Windows
+> **Platforms Supported:** Linux, macOS, Windows
 
 4. Go into `nargo/Cargo.toml` and replace `aztec_backend = ...` with the following:
 
@@ -122,7 +131,7 @@ There are then two approaches to proceed, differing in how the proving backend i
 
 ### Option 2.2: Compile Backend from Source
 
-**Platforms Supported:** Linux, macOS
+> **Platforms Supported:** Linux, macOS
 
 The [barretenberg] proving backend is written in C++, hence compiling it from source would first require certain dependencies to be installed.
 

--- a/src/getting_started/nargo/installation.md
+++ b/src/getting_started/nargo/installation.md
@@ -23,19 +23,19 @@ There are two approaches to install Nargo:
    mkdir C:\nargo
    ```
 
-2. Download the binary package from GitHub into the directory created in Step 1:
+2. Download the binary package from [GitHub Releases](https://github.com/noir-lang/noir/releases/tag/nightly) according to your OS, and move it into the directory created in Step 1:
 
-   - [macOS (Apple Silicon)](https://github.com/kobyhallx/build-noir/suites/9553357751/artifacts/454490397)
-   - [macOS (Intel)](https://github.com/kobyhallx/build-noir/suites/9553357751/artifacts/454490398)
-   - [Windows](https://github.com/kobyhallx/build-noir/suites/9553445421/artifacts/454485541)
+   - macOS (Apple Silicon): `nargo-aarch64-apple-darwin.tar.gz`
+   - macOS (Intel): `nargo-x86_64-apple-darwin.tar.gz`
+   - Windows: `nargo-x86_64-pc-windows-msvc.zip`
 
-3. Paste and run the following in the terminal to extract and expose the binary:
+3. Paste and run the following in the terminal to extract and install the binary:
 
    _macOS (Apple Silicon)_
 
    ```bash
    cd ~/nargo && \
-   unzip nargo-aarch64-apple-darwin.zip && \
+   gunzip -c nargo-aarch64-apple-darwin.tar.gz | tar xopf - && \
    chmod +x nargo && \
    echo '\nexport PATH=$PATH:~/nargo' >> ~/.zshrc && \
    source ~/.zshrc
@@ -45,7 +45,7 @@ There are two approaches to install Nargo:
 
    ```bash
    cd ~/nargo && \
-   unzip nargo-x86_64-apple-darwin.zip && \
+   gunzip -c nargo-x86_64-apple-darwin.tar.gz | tar xopf - && \
    chmod +x nargo && \
    echo '\nexport PATH=$PATH:~/nargo' >> ~/.zshrc && \
    source ~/.zshrc


### PR DESCRIPTION
- Add macOS & Windows installation instructions for binaries
- Update wasm-based `aztec_backend` pointer
- Minor fixes

Preview: https://globallager.github.io/book/getting_started/nargo/installation.html