### PR TITLE
edit linux (bash) command

### DIFF
--- a/src/getting_started/nargo/installation.md
+++ b/src/getting_started/nargo/installation.md
@@ -66,7 +66,7 @@ curl -o $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -L https://github
 tar -xvf $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -C $HOME/.nargo/bin/ && \
 mkdir -p $HOME/.config/noir-lang
 cp -r $HOME/.nargo/bin/noir-lang/* "$HOME/.config/noir-lang/"
-echo '\nexport PATH=$PATH:$HOME/.nargo/bin' >> ~/.bashrc && \
+echo 'export PATH=$PATH:$HOME/.nargo/bin' >> ~/.bashrc && \
 source ~/.bashrc
 ```
 


### PR DESCRIPTION
'export' addition to the bashrc file does not work with '\n'. Removal fixes the problem  