### PR TITLE
Fix GHA syntax to ensure book only builds on master

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -2,7 +2,7 @@ name: github pages
 
 on:
   push:
-    branch: master
+    branches: [master]
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixes issue found in #33 where a push to any branch would deploy the gitbook.