### PR TITLE
Update "Data Types" Page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -13,7 +13,7 @@
   - [Merkle Proof](getting_started/merkle-proof.md)
 - [Language Concepts](language_concepts.md)
   - [Mutability](language_concepts/mutability.md)
-  - [Data types](language_concepts/data_types.md)
+  - [Data Types](language_concepts/data_types.md)
   - [Functions](language_concepts/functions.md)
   - [Comments](language_concepts/comments.md)
   - [Control Flow](language_concepts/control_flow.md)

--- a/src/getting_started/hello_world.md
+++ b/src/getting_started/hello_world.md
@@ -30,7 +30,7 @@ $ nargo new hello_world
 
 > **Note:** `hello_world` can be any arbitrary project name, we are simply using `hello_world` for demonstration.
 >
-> In production, the common practice is to name the project folder as `circuits` for better identifiability when sitting alongside other folders in the codebase (e.g. `contracts`).
+> In production, the common practice is to name the project folder as `circuits` for better identifiability when sitting alongside other folders in the codebase (e.g. `contracts`, `scripts`, `test`).
 
 A `hello_world` folder would be created. Similar to Rust, the folder houses _src/main.nr_ and _Nargo.toml_ that contains the source code and environmental options of your Noir program respectively.
 
@@ -50,11 +50,7 @@ The first line of the program specifies the program's inputs:
 x : Field, y : pub Field
 ```
 
-Program inputs in Noir are private by default (e.g. `x`), but can be labeled public using the keyword `pub` (e.g. `y`).
-
-> **Note:** Private inputs are known only to the prover, while public inputs are shared with the verifier alongside the proof.
->
-> Most projects intend to implement the verifier as a public smart contract, hence public inputs are often considered as public knowledge.
+Program inputs in Noir are private by default (e.g. `x`), but can be labeled public using the keyword `pub` (e.g. `y`). To learn more about private and public values, check the [Data Types](../language_concepts/data_types.md) section.
 
 The next line of the program specifies its body:
 
@@ -64,7 +60,7 @@ constrain x != y;
 
 The Noir syntax `constrain` can be interpreted as something similar to `assert` in other languages.
 
-For more Noir syntax, check the [language chapter](../language_concepts.md).
+For more Noir syntax, check the [Language Concepts](../language_concepts.md) chapter.
 
 ## Build In/Output Files
 

--- a/src/language_concepts/data_types.md
+++ b/src/language_concepts/data_types.md
@@ -189,4 +189,4 @@ fn get_octopus() -> Animal {
 }
 ```
 
-The new variables can be binded with names different from the original struct field names, as showcased in the `legs --> feet` binding in the example above.
+The new variables can be bound with names different from the original struct field names, as showcased in the `legs --> feet` binding in the example above.

--- a/src/language_concepts/data_types.md
+++ b/src/language_concepts/data_types.md
@@ -54,7 +54,7 @@ fn main(x : Field, y : Field)  {
 
 `x`, `y` and `z` are all private fields in this example. Using the `let` keyword we defined a new private value `z` constrained to be equal to `x + y`.
 
-If proving efficiency is of priority, fields should be used as a default for solving problems. Smaller integer types (e.g. `u64`) come with overflow protections at the cost of extra range constraints.
+If proving efficiency is of priority, fields should be used as a default for solving problems. Smaller integer types (e.g. `u64`) incur extra range constraints.
 
 ### Integer Types
 
@@ -93,7 +93,7 @@ A compound type groups together multiple values into one type. Elements within a
 
 ### The Array Type
 
-An array is one way of grouping together values into one compound type. It can be implicitly inferred or explicitly defined with `[<Type>; <Size>]`:
+An array is one way of grouping together values into one compound type. Array types can be inferred or explicitly specified via the syntax `[<Type>; <Size>]`:
 
 ```rust,noplaypen
 fn main(x : Field, y : Field) {
@@ -102,7 +102,7 @@ fn main(x : Field, y : Field) {
 }
 ```
 
-Here, both `my_arr` and `your_arr` are instantiated as an array of `Field` type with `2` elements.
+Here, both `my_arr` and `your_arr` are instantiated as an array containing two `Field` elements.
 
 Array elements can be accessed using indexing:
 
@@ -166,7 +166,7 @@ struct Animal {
 }
 ```
 
-An instance of struct can then be created with actual values in `<Key>: <Value>` pairs of any order. Struct fields are accessible using their given names:
+An instance of a struct can then be created with actual values in `<Key>: <Value>` pairs in any order. Struct fields are accessible using their given names:
 
 ```rust,noplaypen
 fn main() {

--- a/src/language_concepts/mutability.md
+++ b/src/language_concepts/mutability.md
@@ -43,6 +43,63 @@ fn helper(mut x: i32) {
 }
 ```
 
+### Constants
+
+A constant type is a value that does not change per circuit instance. This is different to a witness which changes per proof. If a constant type that is being used in your program is changed, then your circuit will also change.
+
+Below we show how to declare a constant value:
+
+```rust,noplaypen
+fn main() {
+    let a: comptime Field = 5;
+
+    // `comptime Field` can also be inferred:
+    let a = 5;
+}
+```
+
+Note that variables declared as mutable may not be constants:
+
+```rust,noplaypen
+fn main() {
+    // error: Cannot mark a comptime type as mutable - any mutation would remove its const-ness
+    let mut a: comptime Field = 5;
+
+    // a inferred as a private Field here
+    let mut a = 5;
+}
+```
+
+### Globals
+
+Noir also supports global variables. However, they must be compile-time variables. If `comptime` is not explicitly written in the type annotation the compiler will implicitly specify the declaration as compile-time. They can then be used like any other compile-time variable inside functions. The global type can also be inferred by the compiler entirely. Globals can also be used to specify array annotations for function parameters and can be imported from submodules.
+
+Globals are currently limited to Field, integer, and bool literals.
+
+```rust,noplaypen
+global N: Field = 5; // Same as `global N: comptime Field = 5`
+
+fn main(x : Field, y : [Field; N]) {
+    let res = x * N;
+
+    constrain res == y[0];
+
+    let res2 = x * mysubmodule::N;
+    constrain res != res2;
+}
+
+mod mysubmodule {
+    use dep::std;
+
+    global N: Field = 10;
+
+    fn my_helper() -> comptime Field {
+        let x = N;
+        x
+    }
+}
+```
+
 ### Why only local mutability?
 
 Witnesses in a proving system are immutable in nature.


### PR DESCRIPTION
Closes https://github.com/noir-lang/docs/issues/54, Closes https://github.com/noir-lang/docs/issues/43.

# "Data Types" Page Changes
- Add a "Boolean Type" section
- Move Constants & Globals sections out to the "Mutability" page
- Simplify the Tuple example demonstrating access via destructuring
- Modify Struct examples to use less technical terms
- Improve reading / comprehension flow
    - Add a Private & Public Types section
    - Swap the orders to introduce Tuples first then Structs
    - Minor readability edits

# "Hello, World" Page Changes
- Add a reference to the "Data Types" page for more info on private & public values
- Minor fixes