### PR TITLE
Update docs for updates to nightly binaries

### DIFF
--- a/src/getting_started/breakdown.md
+++ b/src/getting_started/breakdown.md
@@ -5,7 +5,7 @@ We elaborate on the project structure and what the `prove` and `verify` commands
 
 ## Anatomy of a Nargo Project
 
-Upon creating a new project with `nargo new` and building the in/output files with `nargo build` commands, you would get a minimal Nargo project of the following structure:
+Upon creating a new project with `nargo new` and building the in/output files with `nargo check` commands, you would get a minimal Nargo project of the following structure:
 
     - src
     - Prover.toml

--- a/src/getting_started/hello_world.md
+++ b/src/getting_started/hello_world.md
@@ -72,7 +72,7 @@ Change directory into _hello_world_ and build in/output files for your Noir prog
 
 ```sh
 $ cd hello_world
-$ nargo build
+$ nargo check
 ```
 
 Two additional files would be generated in your project directory:

--- a/src/getting_started/nargo/commands.md
+++ b/src/getting_started/nargo/commands.md
@@ -17,7 +17,7 @@ _Arguments_
 - `<package_name>` - Name of the package
 - `[path]` - The path to save the new project
 
-## `nargo build`
+## `nargo check`
 
 Generate the `Prover.toml` and `Verifier.toml` files for specifying prover and verifier in/output values of the Noir program respectively.
 
@@ -54,7 +54,7 @@ _Usage_
 
 Running the command would create a new folder `build` with the compiled `<circuit_name>.acir` file in your project directory.
 
-To also compile a witness file, fill in the values in `Prover.toml` generated from `nargo build` and run the command with the `--witness` flag. A `<circuit_name>.tr` file would be compiled in the `build` folder.
+To also compile a witness file, fill in the values in `Prover.toml` generated from `nargo check` and run the command with the `--witness` flag. A `<circuit_name>.tr` file would be compiled in the `build` folder.
 
 > **Info:** The `.acir` file is the ACIR of your Noir program, and the `.tr` file is the witness file. The witness file can be considered as program inputs parsed for your program's ACIR.
 >

--- a/src/getting_started/nargo/installation.md
+++ b/src/getting_started/nargo/installation.md
@@ -114,23 +114,23 @@ SUBCOMMANDS:
    git clone git@github.com:noir-lang/noir.git
    ```
 
-3. Change directory into the Nargo crate by running:
+3. Change directory into the Noir project by running:
 
    ```bash
-   cd noir/crates/nargo
+   cd noir
    ```
 
 There are then two approaches to proceed, differing in how the proving backend is installed:
 
-### Option 2.1: WASM Executable Backend
+### Option 2.1: Install Executable with WASM backend
 
-4. Go into `nargo/Cargo.toml` and replace `aztec_backend = ...` with the following:
+4. Install Nargo by running:
 
+   ```bash
+   cargo install --locked --path=crates/nargo --no-default-features --features plonk_bn254_wasm
    ```
-   aztec_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "484d1f3e780010d04892490641de6a9d92ed805b" }
-   ```
 
-### Option 2.2: Compile Backend from Source
+### Option 2.2: Install Executable with Native Backend
 
 The [barretenberg] proving backend is written in C++, hence compiling it from source would first require certain dependencies to be installed.
 
@@ -158,13 +158,13 @@ The [barretenberg] proving backend is written in C++, hence compiling it from so
    TBC
    ```
 
-### Continue with Installation
-
 5. Install Nargo by running:
 
    ```bash
-   cargo install --locked --path=.
+   cargo install --locked --path=crates/nargo
    ```
+
+### Verify Installation
 
 6. Check if the installation was successful by running `nargo --help`:
 


### PR DESCRIPTION
The nightly binaries have just been published, so we should land these two important doc updates:
1. The `nargo build` command no longer exists
2. The backend patch doesn't make sense because the wasm backend can be enabled with a flag

Closes noir-lang/docs#39 
Closes noir-lang/docs#53