### PR TITLE
Add entry for `nargo execute` command

### DIFF
--- a/src/getting_started/nargo/commands.md
+++ b/src/getting_started/nargo/commands.md
@@ -21,6 +21,12 @@ _Arguments_
 
 Generate the `Prover.toml` and `Verifier.toml` files for specifying prover and verifier in/output values of the Noir program respectively.
 
+## `nargo execute`
+
+Runs the Noir program and prints its return value.
+
+- `<witness_name>` - The name of the witness
+
 ## `nargo prove <proof_name>`
 
 Creates a proof for the program.


### PR DESCRIPTION
This PR adds a small entry on the "Commands" page for `nargo execute`.

Waiting on https://github.com/noir-lang/noir/pull/725

Closes noir-lang/docs#33 