### PR TITLE
ci: add monitoring for dead links in docs

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -20,7 +20,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.5.4
         with:
-          args: "--verbose  --no-progress --cache src/"
+          args: "--verbose --no-progress --cache src/"
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,26 @@
+name: Markdown
+
+on:
+  push:
+
+jobs:
+  dead-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Restore lychee cache
+        uses: actions/cache@v3
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.5.4
+        with:
+          args: "--verbose  --no-progress --cache src/"
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -1,0 +1,24 @@
+name: Monitoring
+
+on:
+  schedule:
+    - cron: "00 00 * * *"
+
+jobs:
+  dead-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.5.4
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md


### PR DESCRIPTION
closes noir-lang/docs#32 

This PR adds a task to check that all of the links on the site work (i.e. no external links have gone bad and no internal links point to non-existent files) once a day at midnight. If there are non-functioning links then an issue is created.

We also perform these checks on each pushed commit to allow us to catch errors more quickly. External requests are cached so this is an extremely cheap check to perform.